### PR TITLE
Expanded on this syntax

### DIFF
--- a/endless-sky.sublime-syntax
+++ b/endless-sky.sublime-syntax
@@ -16,6 +16,9 @@ contexts:
         - meta_scope: support.type.endless-sky
         - match: '$'
           pop: true
+    - match: 'random'
+      scope: support.type.endless-sky
+      push: value
     - match: '^\w+'
       comment: Expect a value
       scope: support.type.endless-sky
@@ -36,6 +39,9 @@ contexts:
       push: bstring
 
   value:
+    - match: ' random'
+      scope: support.type.endless-sky
+      push: value
     - include: string_detection
     - match: ' ?(\+\+|--|==?|[+-]=|[<>])'
       comment: Increment, decrement or comparison

--- a/endless-sky.sublime-syntax
+++ b/endless-sky.sublime-syntax
@@ -26,7 +26,7 @@ contexts:
     - match: '\w+'
       scope: entity.name.endless-sky
       push: value
-    - match: '^\s+(["`])?.{0,}?\1[^\n]'
+    - match: '^\s+("|`)?.{0,}?\1[^\n]'
       scope: entity.name.endless-sky
       push: value
     - include: comments
@@ -46,13 +46,13 @@ contexts:
     - match: ' ?(\+\+|--|==?|[+-]=|[<>])'
       comment: Increment, decrement or comparison
       scope: keyword.control.endless-sky
-    - match: ' ?([-])?[0-9.]+'
+    - match: ' ?-?[0-9.]+'
       comment: Number
       scope: constant.numeric.endless-sky
     - match: ' '
       comment: Non-quoted string
       push: implicit_string
-    - match: '( +)\w+'
+    - match: ' +\w+'
       scope: entity.name.endless-sky
     - match: $
       comment: End of line

--- a/endless-sky.sublime-syntax
+++ b/endless-sky.sublime-syntax
@@ -1,66 +1,84 @@
 %YAML 1.2
 ---
 name: Endless Sky
-# See http://www.sublimetext.com/docs/3/syntax.html
 file_extensions:
   - txt
 scope: source.endless-sky
 
 contexts:
-  # The prototype context is prepended to all contexts but those setting
-  # meta_include_prototype: false.
   main:
-    # The main context is the initial starting point of our syntax.
-    - match: '(to|on|not|neighbour)' # This are multiple-words keywords, such as "to offer", or "on complete"
-      scope: keyword.control.endless-sky
+    - match: '(to|on|not|neighbour)'
+      comment: This are multiple-words keywords, such as "to offer", or "on complete"
+      scope: entity.name.endless-sky
+    - match: 'npc'
+      scope: entity.name.endless-sky
+      push:
+        - meta_scope: support.type.endless-sky
+        - match: '$'
+          pop: true
     - match: '^\w+'
-      scope: support.type.endless-sky # In the beggining of the line "planet Earth" is highlighted blue
-      push: value # Expect a value
-    - match: '\w+'
-      scope: keyword.control.endless-sky
+      comment: Expect a value
+      scope: support.type.endless-sky
       push: value
+    - match: '\w+'
+      scope: entity.name.endless-sky
+      push: value
+    - match: '^\s+(["`])?.{0,}?\1[^\n]'
+      scope: entity.name.endless-sky
+      push: value
+    - include: comments
     - include: string_detection
-  string_detection:
-    - match: ' "'
-      push: string
-    - match: '"'
-      push: string
-    - match: '`'
-      push: bstring
-    - match: ' `'
-      push: bstring
-  value:
 
+  string_detection:
+    - match: ' ?"'
+      push: string
+    - match: ' ?`'
+      push: bstring
+
+  value:
     - include: string_detection
-    - match: " (-)?[0-9.]+" # Number
+    - match: ' ?(\+\+|--|==?|[+-]=|[<>])'
+      comment: Increment, decrement or comparison
+      scope: keyword.control.endless-sky
+    - match: ' ?([-])?[0-9.]+'
+      comment: Number
       scope: constant.numeric.endless-sky
-    - match: "(-)?[0-9.]+" # Number
-      scope: constant.numeric.endless-sky
-    - match: ' ' # Non-quoted string
+    - match: ' '
+      comment: Non-quoted string
       push: implicit_string
     - match: '( +)\w+'
-      scope: keyword.control.endless-sky
-    - match: $\n? # End of line
+      scope: entity.name.endless-sky
+    - match: $
+      comment: End of line
       pop: true
     - match: '.'
       scope: string.unquoted.endless-sky
+
   implicit_string:
     - meta_scope: string.unquoted.endless-sky
     - match: ' '
       pop: true
-    - match: $\n?
+    - match: $
       pop: true
-  string:
 
+  string:
     - meta_scope: string.quoted.double.endless-sky
     - match: \\.
       scope: constant.character.escape.endless-sky
     - match: '"'
       pop: true
-  bstring: # Backtick string
+
+  bstring:
     - meta_scope: string.quoted.backtick.endless-sky
     - match: \\.
       scope: constant.character.escape.endless-sky
-
     - match: '`'
       pop: true
+
+  comments:
+    - match: '#'
+      scope: punctuation.definition.comment.endless-sky
+      push:
+        - meta_scope: comment.line.number-sign.endless-sky
+        - match: $\n?
+          pop: true


### PR DESCRIPTION
Biggest problem is differentiating between actual Strings and Keywords

```
fleet "Korath Raid"
	add variant
		"Korath Raider"
		"Korath Stalker" 2
```

The `"Korath Raider"` gets treated as string, the `"Korath Stalker" 2` as keyword and argument pair.